### PR TITLE
Revert "MNT: remove script"

### DIFF
--- a/cagateway-ssh
+++ b/cagateway-ssh
@@ -1,0 +1,48 @@
+#!/bin/sh
+set -e -x
+#
+# cagateway-ssh
+# cagateway-ssh $CAPORT
+# cagateway-ssh $CAPORT $GWPORT
+#
+# Run cagateway for use with SSH port forwarding
+#   $ ssh -L 5064:localhost:5064 iochost
+# or
+#   $ ssh -L 5064:iochost:5064 sshgw
+#
+# For non-stanard CA port eg. 15064
+#  -L 5064:localhost:15064
+
+# The local port which is being forwarded
+CAPORT=${1:-5064}
+# local TCP port where GW will listen (can't be the same as $CAPORT)
+GWPORT=${2:-${RANDOM}}
+
+WORK=`mktemp -d`
+
+trap "rm -rf $WORK" INT TERM QUIT EXIT
+
+cd "$WORK"
+
+# Allow all access
+cat << EOF > access
+ASG(DEFAULT) {
+  RULE(1,WRITE)
+}
+EOF
+
+# Allow all PVs
+cat << EOF > pvlist
+EVALUATION ORDER ALLOW, DENY
+.* ALLOW
+EOF
+
+# cagateway TCP port
+export EPICS_CAS_SERVER_PORT=$GWPORT
+
+# Lookup only through SSH and localhost UDP
+export EPICS_CA_NAME_SERVERS=localhost:$CAPORT
+export EPICS_CA_ADDR_LIST=localhost
+export EPICS_CA_AUTO_ADDR_LIST=NO
+
+cagateway -pvlist pvlist -access access

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,12 +1,8 @@
-epics-cagateway (2.0.6.0-2) unstable; urgency=low
+epics-cagateway (2.0.6.0-2) UNRELEASED; urgency=medium
 
-  [ mdavidsaver ]
   * Add cagateway-ssh helper script for use with ssh port forwarding
 
-  [ Daron Chabot ]
-  * MNT: remove script
-
- -- Daron Chabot <chabot@frib.msu.edu>  Wed, 15 Nov 2017 11:12:37 -0500
+ -- mdavidsaver <mdavidsaver@gmail.com>  Thu, 29 Sep 2016 18:57:08 -0400
 
 epics-cagateway (2.0.6.0-1) unstable; urgency=medium
 

--- a/debian/epics-cagateway.install
+++ b/debian/epics-cagateway.install
@@ -1,0 +1,1 @@
+cagateway-ssh usr/bin


### PR DESCRIPTION
Reverts epicsdeb/epics-cagateway#4

This PR introduced a conflict with the 2.1.1.0 upstream update PR, where the script is added via a patch. Since the script itself doesn't hurt this way, it's easier to revert this PR and merge 2.1.1.0 before going to the new 2.1.2.0